### PR TITLE
Return error exit code

### DIFF
--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -115,6 +115,7 @@ export function checkPeerDependencies(packageManager: string, options: CliOption
         process.exit(5)
       }
     }
+    return;
 
   } else if (commandLines.length > 0) {
     console.log(`Install peerDependencies using ${commandLines.length > 1 ? 'these commands:' : 'this command'}:`);
@@ -122,6 +123,7 @@ export function checkPeerDependencies(packageManager: string, options: CliOption
     commandLines.forEach(command => console.log(command));
     console.log();
   }
+  process.exit(5);
 }
 
 

--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -123,7 +123,7 @@ export function checkPeerDependencies(packageManager: string, options: CliOption
     commandLines.forEach(command => console.log(command));
     console.log();
   }
-  process.exit(5);
+  process.exit(1);
 }
 
 


### PR DESCRIPTION
It fixes #2

Hi @christopherthielen! This tool is just what I need, and the code is very clear and concise.

I just need something else in order to include it in my CI pipeline: I need that the tool returns an error exit code when the peer dependencies are not satisfied.

I think that it should be returned only when the `install` option is not set.

There is a kind of recursivity that I am not sure to understand, so, I am not sure that my change is totally right.

Could you kindly review it and comment to me if my change (or another related) is merged and published?