### PR TITLE
move walkPackageDependencyTree to if condition.

### DIFF
--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -90,10 +90,9 @@ export function walkPackageDependencyTree(packagePath: string, visitor: Dependen
     }
 
     const dependencyPath = resolvePackageDir(packagePath, dependency.name);
-    if (!dependencyPath) {
-      throw new Error(`Unable to resolve package ${dependency.name} from ${packagePath}`)
+    if (dependencyPath) {
+      walkPackageDependencyTree(dependencyPath, visitor, visitedPaths, options);
     }
-    walkPackageDependencyTree(dependencyPath, visitor, visitedPaths, options);
   }
 
   packageDependencies.dependencies.forEach(walkDependency);


### PR DESCRIPTION
This is will fix issue related to this type of errors "Unable to resolve package fsevents error (While using this tool from Windows)"
Issue: https://github.com/christopherthielen/check-peer-dependencies/issues/4