### PR TITLE
refactor: Package dependency check for package.json deps.

### DIFF
--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -97,8 +97,10 @@ export function walkPackageDependencyTree(packagePath: string, visitor: Dependen
     }
   }
 
-  packageDependencies.dependencies.forEach(walkDependency);
-  if (isRootPackage) packageDependencies.devDependencies.forEach(walkDependency);
+  if (isRootPackage) {
+    packageDependencies.dependencies.forEach(walkDependency);
+    packageDependencies.devDependencies.forEach(walkDependency);
+  }
 }
 
 function buildDependencyArray(packagePath: string, packageJson: PackageJson, dependenciesObject: any): Dependency[] {


### PR DESCRIPTION
Getting package version conflict issues while running walkDependency on all the packages which are present on node_modules. 
Ex: 
- `ts-jest` and `cypress-image-snapshot` are declared as devDeps in project package.json
- ts-jest has peerDep of `jest` (We added required jest to project package.json)
- `cypress-image-snapshot` (Doesn't have `jest` as peerDep but in `cypress-image-snapshot` package.json it has devDependency of `jest-image-snapshot` and `jest-image-snapshot` has peerDep of `jest`) 
- And in this case, our tool reports for a missing peerDep i.e., `jest-image-snapshot required some jest version >23 and <24`