### PR TITLE
fix: Install peer deps as devDependencies if the peer dep came from a dev dependency

### DIFF
--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -24,12 +24,12 @@ export function getCommandLines(packageManager: string, resolutions: Resolution[
     if (upgrades.length) {
       commands.push(`yarn upgrade ${upgrades.join(' ')}`);
     }
-  } else if (packageManager === 'npm' && (installs.length || upgrades.length)) {
+  } else if (packageManager === 'npm' && (installs.length || upgrades.length || devInstalls.length)) {
     if (installs.length || upgrades.length) {
       commands.push(`npm install ${installs.concat(upgrades).join(' ')}`);
     }
     if (devInstalls.length) {
-      commands.push(`npm install -D ${installs.concat(upgrades).join(' ')}`);
+      commands.push(`npm install -D ${devInstalls}`);
     }
   }
   return commands;


### PR DESCRIPTION
fix: Properly install dev dependencies when using npm as the package manager