### PR TITLE
chore: install command option cannot be used in yarn version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ Searching for solutions:
 ❌  Unable to find a version of @angular/common that satisfies the following peerDependencies: 9.0.0-next.9 and ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 ❌  Unable to find a version of @angular/core that satisfies the following peerDependencies: 9.0.0-next.9 and ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-yarn upgrade @angular/router@8.2.10
+yarn up @angular/router@8.2.10
 ```
 

--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -22,7 +22,7 @@ export function getCommandLines(packageManager: string, resolutions: Resolution[
       commands.push(`yarn add -D ${devInstalls.join(' ')}`);
     }
     if (upgrades.length) {
-      commands.push(`yarn upgrade ${upgrades.join(' ')}`);
+      commands.push(`yarn up ${upgrades.join(' ')}`);
     }
   } else if (packageManager === 'npm' && (installs.length || upgrades.length || devInstalls.length)) {
     if (installs.length || upgrades.length) {


### PR DESCRIPTION
In some install command option cases cannot be used in yarn version 2, So I requested this PR.