### PR TITLE
fix: Method for determining the installed version fails #27

### DIFF
--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -162,7 +162,9 @@ export function resolvePackageDir(basedir: string, packageName: string) {
   // In resolve() v2.x this callback has a different signature
   // function packageFilter(pkg, pkgfile, pkgdir) {
   function packageFilter(pkg, pkgdir) {
-    packagePath = pkgdir;
+    if (!packagePath || pkg.version) {
+      packagePath = pkgdir;
+    }
     return pkg;
   }
 


### PR DESCRIPTION
fix #27 
@christopherthielen can you please CR? This is a super small fix

The fix handles cases where `main` references a dir that has an additional incomplete nested package.json without a version set to it.

For example: https://unpkg.com/browse/i18next-http-backend@2.1.1/cjs/package.json