### PR TITLE
Only check internal packages; Add feature flag

### DIFF
--- a/README-ATLASSIAN.md
+++ b/README-ATLASSIAN.md
@@ -1,0 +1,15 @@
+# Atlassian fork of check-peer-dependencies
+
+This fork contains some modifications that only check internal peer dependencies which are scoped under `@atlaskit`, `@atlassian` or `@atlassiansox`.
+
+## Changes
+
+1. Only check peer dependencies for internal packages
+2. Add feature flag https://app.launchdarkly.com/atlassian-frontend/production/features/peer-dependency-enforcement_operational/targeting to turn on/off the check
+3. Skip the check when on certain branch. This is mainly used to bypass the check in product integrator.
+
+## Build&Publish
+
+1. bump the version in package.json
+2. run `yarn build`
+3. run `npm publish`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "check-peer-dependencies",
-  "version": "4.2.0",
+  "name": "@atlassian/check-peer-dependencies",
+  "version": "0.0.1-alpha.2",
   "description": "Checks peer dependencies of the current package.  Offers solutions for any that are unmet.",
   "main": "dist/check_peer_dependencies.js",
   "scripts": {
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/christopherthielen/check-peer-dependencies#readme",
   "dependencies": {
+    "launchdarkly-node-client-sdk": "^2.1.0",
     "resolve": "^1.19.0",
     "semver": "^7.3.4",
     "shelljs": "^0.8.4",

--- a/src/featureFlag.ts
+++ b/src/featureFlag.ts
@@ -1,0 +1,62 @@
+import * as ld from 'launchdarkly-node-client-sdk';
+import { getCurrentBranch } from './gitUtils';
+
+let launchdarklyClient: LaunchdarklyClient;
+
+class LaunchdarklyClient {
+  clientId: string;
+  client: ld.LDClient;
+
+  constructor(clientId: string) {
+    this.clientId = clientId;
+  }
+
+  private async initClient() {
+    const user: ld.LDUser = {
+      key: 'atlassian-frontend',
+      custom: {
+        branchName: await getCurrentBranch()
+      },
+    };
+    const client = ld.initialize(this.clientId, user, { logger: ld.basicLogger({ level: 'none' }) });
+    await client.waitForInitialization();
+    this.client = client;
+  }
+
+  public async getFeature<T extends string | boolean | number>(flagName: string, defaultResult: T): Promise<T> {
+    if (!this.client) {
+      await this.initClient();
+    }
+    
+    const result: T = await this.client.variation(flagName, defaultResult);
+    await this.client.flush();
+
+    if (!(typeof result === 'boolean' || typeof result === 'string' || typeof result === 'number')) {
+      console.log(
+        `${flagName} feature flag value (${result}) has invalid type: ${typeof result}. Falling back to default value`,
+      );
+      return defaultResult;
+    }
+
+    return result;
+  }
+}
+
+function getLaunchdarklyClient(launchdarklyClientId: string) {
+  if (launchdarklyClient) {
+    return launchdarklyClient;
+  } else {
+    launchdarklyClient = new LaunchdarklyClient(launchdarklyClientId);
+    return launchdarklyClient;
+  }
+}
+
+export async function getPeerDepCheckFF(launchdarklyClientId: string) {
+  try {
+    const launchdarklyClient = getLaunchdarklyClient(launchdarklyClientId);
+    return launchdarklyClient.getFeature('peer-dependency-enforcement_operational', false);
+  } catch(error) {
+    console.log(error);
+    return false;
+  }
+}

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -1,0 +1,14 @@
+import * as child_process from 'child_process';
+import * as util from 'util';
+
+const exec = util.promisify(child_process.exec);
+
+export async function getCurrentBranch() {
+  try {
+    const output = await exec('git rev-parse --abbrev-ref HEAD');
+    return output.stdout.trim();
+  } catch(error) {
+    console.log(error)
+    return ''
+  }
+}

--- a/src/readJson.ts
+++ b/src/readJson.ts
@@ -1,5 +1,21 @@
 import { readFileSync } from 'fs';
+
+interface ConfigJson {
+  enforcedPackages?: string[];
+  ignoredBranchPrefixes?: string[];
+  launchdarklyClientId?: string;
+}
+
 export function readJson(filename: string) {
   return JSON.parse(readFileSync(filename).toString('utf-8'));
+}
+
+export function getConfig(configPath: string): ConfigJson {
+  try {
+    return readJson(configPath);
+  } catch(error) {
+    console.log(error)
+    return {};
+  }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,6 +174,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -600,6 +605,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -731,6 +741,11 @@ glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+graceful-fs@^4.1.11:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
@@ -798,6 +813,11 @@ ignore@^5.0.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -972,6 +992,31 @@ kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+launchdarkly-eventsource@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/launchdarkly-eventsource/-/launchdarkly-eventsource-1.4.3.tgz#48811a970bf01c9d34ea7d2b4c9f9c10fa15ea61"
+  integrity sha512-taeidSNMbF4AuUXjoFStT5CSTknicaKqu+0vrw7gYEMrpQgG74BEzlS0BGYmxW20JdGm2gpm7jtZ542ZG/h8tA==
+  dependencies:
+    original "^1.0.2"
+
+launchdarkly-js-sdk-common@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-4.3.3.tgz#adac341b5cd7720116584161c54caff0a5111d7f"
+  integrity sha512-COLKk6JxrP+xFrp7gQMGta19uLik/Gy2iq151lydxRfPbmWcY0BCfW/Y8uTTSjI1r4fLGdWsupIiY0ojhGXu8w==
+  dependencies:
+    base64-js "^1.3.0"
+    fast-deep-equal "^2.0.1"
+    uuid "^8.0.0"
+
+launchdarkly-node-client-sdk@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/launchdarkly-node-client-sdk/-/launchdarkly-node-client-sdk-2.2.2.tgz#e51cd565525a7e03163b997398962b6090cc003d"
+  integrity sha512-rWXqAS6yXZ7jJdPkbJTij+HR+MbdlItczUxy2JPbSK+ofv4tOhR39ktJSKfqa3go7xwPabKSgaDRf+exP77d3w==
+  dependencies:
+    launchdarkly-eventsource "1.4.3"
+    launchdarkly-js-sdk-common "4.3.3"
+    node-localstorage "^1.3.1"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -1186,6 +1231,13 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
+node-localstorage@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-1.3.1.tgz#3177ef42837f398aee5dd75e319b281e40704243"
+  integrity sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==
+  dependencies:
+    write-file-atomic "^1.1.4"
+
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -1268,6 +1320,13 @@ open@^7.0.4:
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
+
+original@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
+  integrity sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==
+  dependencies:
+    url-parse "^1.4.3"
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -1422,6 +1481,11 @@ q@^1.4.1, q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -1560,6 +1624,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve@^1.1.6, resolve@^1.10.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
@@ -1674,6 +1743,11 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==
 
 source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
@@ -1913,10 +1987,23 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+url-parse@^1.4.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -1965,6 +2052,15 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  integrity sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Forked this package and made a few changes:

1. Only check peer dependencies for internal packages
2. Add [feature flag](https://app.launchdarkly.com/atlassian-frontend/production/features/peer-dependency-enforcement_operational/targeting) to turn on/off the check
3. Skip the check when on certain branch. This is mainly used to bypass the check in product integrator.