### PR TITLE
installed optional peer deps that are not satisfied should error

### DIFF
--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -28,7 +28,8 @@ function getAllNestedPeerDependencies(options: CliOptions): Dependency[] {
 
 let recursiveCount = 0;
 
-const isProblem = (dep: Dependency) => !dep.isIgnored && !dep.isYalc && !dep.semverSatisfies && (!dep.isPeerOptionalDependency ? true : dep.installedVersion);
+const isProblem = (dep: Dependency) => !dep.semverSatisfies && !dep.isIgnored && !dep.isYalc &&
+    (!dep.isPeerOptionalDependency || !!dep.installedVersion);
 
 const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSatisfiedDep: boolean, verbose: boolean) => {
   const message = byDepender ?
@@ -37,7 +38,7 @@ const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSa
 
   if (dep.semverSatisfies) {
     if (showSatisfiedDep) {
-      console.log(`  ☑️  ${message} (${dep.installedVersion} is installed)`);
+      console.log(`  ✅  ${message} (${dep.installedVersion} is installed)`);
     }
   } else if (dep.isYalc) {
     console.log(`  ☑️  ${message} (${dep.installedVersion} is installed via yalc)`);

--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -28,7 +28,7 @@ function getAllNestedPeerDependencies(options: CliOptions): Dependency[] {
 
 let recursiveCount = 0;
 
-const  isProblem = (dep: Dependency) => !dep.semverSatisfies && !dep.isIgnored && !dep.isYalc && !dep.isPeerOptionalDependency;
+const isProblem = (dep: Dependency) => !dep.isIgnored && !dep.isYalc && !dep.semverSatisfies && (!dep.isPeerOptionalDependency ? true : dep.installedVersion);
 
 const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSatisfiedDep: boolean, verbose: boolean) => {
   const message = byDepender ?
@@ -41,14 +41,12 @@ const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSa
     }
   } else if (dep.isYalc) {
     console.log(`  ☑️  ${message} (${dep.installedVersion} is installed via yalc)`);
-  } else if (dep.installedVersion && dep.isPeerOptionalDependency) {
-    if (verbose) {
-      console.log(`  ☑️   ${message}) OPTIONAL (${dep.installedVersion} is installed)`);
-    }
   } else if (dep.isIgnored) {
     if (verbose) {
       console.log(`  ☑️   ${message} IGNORED (${dep.name} is not installed)`);
     }
+  } else if (dep.installedVersion && dep.isPeerOptionalDependency) {
+    console.log(`  ✅  ${message}) OPTIONAL (${dep.installedVersion} is installed)`);
   } else if (dep.installedVersion) {
     console.log(`  ❌  ${message}) (${dep.installedVersion} is installed)`);
   } else if (dep.isPeerOptionalDependency) {

--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -37,7 +37,7 @@ const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSa
 
   if (dep.semverSatisfies) {
     if (showSatisfiedDep) {
-      console.log(`  ✅  ${message} (${dep.installedVersion} is installed)`);
+      console.log(`  ☑️  ${message} (${dep.installedVersion} is installed)`);
     }
   } else if (dep.isYalc) {
     console.log(`  ☑️  ${message} (${dep.installedVersion} is installed via yalc)`);
@@ -45,10 +45,12 @@ const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSa
     if (verbose) {
       console.log(`  ☑️   ${message} IGNORED (${dep.name} is not installed)`);
     }
-  } else if (dep.installedVersion && dep.isPeerOptionalDependency) {
-    console.log(`  ✅  ${message}) OPTIONAL (${dep.installedVersion} is installed)`);
   } else if (dep.installedVersion) {
-    console.log(`  ❌  ${message}) (${dep.installedVersion} is installed)`);
+    if (dep.isPeerOptionalDependency) {
+      console.log(`  ❌  ${message}) OPTIONAL (${dep.installedVersion} is installed)`);
+    } else {
+      console.log(`  ❌  ${message}) (${dep.installedVersion} is installed)`);
+    }
   } else if (dep.isPeerOptionalDependency) {
     if (verbose) {
       console.log(`  ☑️   ${message} OPTIONAL (${dep.name} is not installed)`);


### PR DESCRIPTION
consider the following scenario:
- dep B defines dep C as an optional peer dep with semver ^5
- dep A has B as a dependency
- dep A has C as a dependency with semever ^6

Currently, this will not alert - even though semver is not satisfied, the peer is optional and thus ignored.

This is a wrong behavior... The reason is that at runtime, B will try to check if C is installed, and if it is, it will use it. But in our scenario it expects C to be ^5, but we have ^6 which can lead to unexpected behavior at runtime.

This PR fixes that scenario and alerts if optional peer is installed but doesn't satisfy the semver.