### PR TITLE
Add `includePrerelease` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Options:
                                                       [boolean] [default: false]
       --install                    Install missing or incorrect peerDependencies
                                                       [boolean] [default: false]
+      --includePrerelease          Include prerelease versions when searching
+                                   for solutions
+                                                      [boolean] [default: true]
 ```
 
 ---

--- a/src/checkPeerDependencies.ts
+++ b/src/checkPeerDependencies.ts
@@ -61,11 +61,11 @@ const reportPeerDependencyStatus = (dep: Dependency, byDepender: boolean, showSa
   }
 };
 
-function findSolutions(problems: Dependency[], allNestedPeerDependencies: Dependency[]) {
+function findSolutions(problems: Dependency[], allNestedPeerDependencies: Dependency[], options: CliOptions) {
   console.log();
   console.log(`Searching for solutions for ${problems.length} missing dependencies...`);
   console.log();
-  const resolutions: Resolution[] = findPossibleResolutions(problems, allNestedPeerDependencies);
+  const resolutions: Resolution[] = findPossibleResolutions(problems, allNestedPeerDependencies, options.includePrerelease);
   const resolutionsWithSolutions = resolutions.filter(r => r.resolution);
   const nosolution = resolutions.filter(r => !r.resolution);
 
@@ -140,14 +140,14 @@ export function checkPeerDependencies(packageManager: string, options: CliOption
   }
 
   if (options.install) {
-    const { nosolution, resolutionsWithSolutions } = findSolutions(problems, allNestedPeerDependencies);
+    const { nosolution, resolutionsWithSolutions } = findSolutions(problems, allNestedPeerDependencies, options);
     const commandLines = getCommandLines(packageManager, resolutionsWithSolutions);
 
     if (commandLines.length) {
       return installPeerDependencies(commandLines, options, nosolution, packageManager);
     }
   } else if (options.findSolutions) {
-    const { resolutionsWithSolutions } = findSolutions(problems, allNestedPeerDependencies);
+    const { resolutionsWithSolutions } = findSolutions(problems, allNestedPeerDependencies, options);
     const commandLines = getCommandLines(packageManager, resolutionsWithSolutions);
 
     if (commandLines.length) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,11 @@ const options = yarrrrgs
       default: [],
       description: 'package name to ignore (may specify multiple)',
     })
+    .option('includePrerelease', {
+      boolean: true,
+      default: true,
+      description: 'Include prerelease versions when searching for solutions',
+    })
     .option('runOnlyOnRootDependencies', {
         boolean: true,
         default: false,
@@ -70,6 +75,7 @@ export interface CliOptions {
   debug: boolean;
   npm: boolean;
   ignore: string[];
+  includePrerelease: boolean;
   runOnlyOnRootDependencies: boolean;
   orderBy: 'depender' | 'dependee';
   findSolutions: boolean;

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -19,19 +19,19 @@ export interface Resolution {
   resolutionType: 'upgrade' | 'install' | 'devInstall';
 }
 
-export function findPossibleResolutions(problems: Dependency[], allPeerDependencies: Dependency[], ): Resolution[] {
+export function findPossibleResolutions(problems: Dependency[], allPeerDependencies: Dependency[], includePrerelease: boolean): Resolution[] {
   const uniq: Dependency[] = problems.reduce((acc, problem) => acc.some(dep => dep.name === problem.name) ? acc : acc.concat(problem), []);
   return uniq.map(problem => {
     const shouldUpgrade = !!problem.installedVersion;
     const resolutionType = shouldUpgrade ? 'upgrade' : problem.isPeerDevDependency ? 'devInstall' : 'install';
-    const resolutionVersion = findPossibleResolution(problem.name, allPeerDependencies);
+    const resolutionVersion = findPossibleResolution(problem.name, allPeerDependencies, includePrerelease);
     const resolution = resolutionVersion ? `${problem.name}@${resolutionVersion}` : null;
 
     return { problem, resolution, resolutionType } as Resolution;
   })
 }
 
-function findPossibleResolution(packageName, allPeerDeps) {
+function findPossibleResolution(packageName, allPeerDeps, includePrerelease) {
   const requiredPeerVersions = allPeerDeps.filter(dep => dep.name === packageName);
   // todo: skip this step if only one required peer version and it's an exact version
   const command = `npm view ${packageName} versions`;
@@ -40,7 +40,7 @@ function findPossibleResolution(packageName, allPeerDeps) {
     rawVersionsInfo = exec(command, { silent: true }).stdout;
     const availableVersions = JSON.parse(rawVersionsInfo.replace(/'/g, '"')).sort(semverReverseSort);
     return availableVersions.find(ver => requiredPeerVersions.every(peerVer => {
-      return semver.satisfies(ver, peerVer.version, { includePrerelease: true });
+      return semver.satisfies(ver, peerVer.version, { includePrerelease });
     }));
   } catch (err) {
     console.error(`Error while running command: '${command}'`);


### PR DESCRIPTION
Currently `includePrerelease` always is `true`,

But sometimes we need stable version, like `vite`,

Support includePrerelease options, and not change the default action.

After this PR, can use `--includePrerelease=false` to prevent install pre release version.

closed #53 